### PR TITLE
added write_envi function to emit_tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.nc*
 /data/example_out.csv
 /data/isla_gaviota_3.geojson
+/data/outputs
+/data/envi
 /ignore
 *__pycache__*
 /data/emit_asset_urls.txt

--- a/README.md
+++ b/README.md
@@ -1,20 +1,6 @@
-# EMIT Data Tutorials Workshop - February 2023
+# EMIT-Data-Resources
 
->**This branch of the repository is specifically for the EMIT Data Tutorials Workshops hosted February 3, 10, and 17th from 1:00 - 3:00pm EST and is designed specifically for the cloud computing instance used during weeks 2 and 3. If you want to work through the content in this repo locally, please clone the main branch. This workshop branch will remain available to launch the cloud instance if you are a participant and want to revisit it.**
-
-[Workshop Sign-up Page](https://tinyurl.com/2tp3cx3t)
-
-To launch the Openscapes 2i2c cloud computing instance, please click the link below and select a `Large: up to 64 CPU/512 GB RAM with a Python Image and Node Share: ~2CPU, ~16GB RAM. This will automatically configure your space with the needed environment and repository for the workshop, no completion of prerequisite tasks or setup will be necessary.
-
-> Running multiple notebooks simultaneously or in a row may result in an error due to shared resources on the cloud instance. If this happens, using the menu bar at the top of your browser, go to Kernel > Shut down all kernels... This will shut down any kernels remaining in the background that are using memory.
-
-[Launch Workshop Cloud Instance](https://openscapes.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fnasa%2FEMIT-Data-Resources&urlpath=lab%2Ftree%2FEMIT-Data-Resources%2F&branch=emit_workshop_feb2023)  
-
-![Server Selection Figure](./data/figures/server_selection.png)
-
----  
-
-## EMIT-Data-Resources  
+>**This version of the workshop is designed to be completed locally. If you want use the cloud workspace to revisit the EMIT Data Tutorials Workshops hosted February 3, 10, and 17th 2023, clone the emit_workshop_feb2023 branch. The workshop branch will remain available.**
 
 Welcome to the EMIT-Data-Resources repository. This repository provides guides, short how-tos, and tutorials to help users access and work with data from the Earth Surface Mineral Dust Source Investigation (EMIT) mission. In the interest of open science this repository has been made public but is still under active development. All jupyter notebooks and scripts should be functional, however, changes or additions may be made. Contributions from all parties are welcome.
 
@@ -88,6 +74,6 @@ Email: LPDAAC@usgs.gov
 Voice: +1-866-573-3222  
 Organization: Land Processes Distributed Active Archive Center (LP DAAC)¹  
 Website: <https://lpdaac.usgs.gov/>  
-Date last modified: 02-09-2023  
+Date last modified: 02-21-2023  
 
 ¹Work performed under USGS contract G15PD00467 for NASA contract NNG14HH33I.  

--- a/modules/emit_tools.py
+++ b/modules/emit_tools.py
@@ -7,12 +7,15 @@ Author: Erik Bolch, ebolch@contractor.usgs.gov
 Last Updated: 02/16/2022
 
 TO DO: 
+- Add units to metadata for ENVI header
 - Fix elevation orthorectification - all values end up as -9999
 - Investigate reducing memory usage
 - Test/Improve flexibility for applying the GLT to modified datasets
 """
 # Packages used
 import netCDF4 as nc
+import os
+from spectral.io import envi
 from osgeo import gdal
 import numpy as np
 import math
@@ -43,6 +46,7 @@ def emit_xarray(filepath, ortho=True, qmask=None, unpacked_bmask=None):
     data_vars = {**ds.variables} 
     coords = {'downtrack':(['downtrack'], ds.downtrack.data),'crosstrack':(['crosstrack'],ds.crosstrack.data), **loc.variables, **wvl.variables}
     out_xr = xr.Dataset(data_vars=data_vars, coords = coords, attrs= ds.attrs)
+    out_xr.attrs['granule_id'] = os.path.splitext(os.path.basename(filepath))[0]
     
     # Apply Quality and Band Masks
     if qmask is not None:
@@ -52,7 +56,8 @@ def emit_xarray(filepath, ortho=True, qmask=None, unpacked_bmask=None):
     
     if ortho is True:
        out_xr = ortho_xr(out_xr)
-          
+       out_xr.attrs['Orthorectified'] = 'True'
+              
     return out_xr
 
 
@@ -226,3 +231,144 @@ def band_mask(filepath):
     unpacked_bmask = unpacked_bmask[:,:,0:285]
     # Check for data bands and build mask
     return(unpacked_bmask)
+
+def write_envi(xr_ds, output_dir, overwrite=False, extension='.img', interleave='bil', glt_file=False):
+    """
+    This function takes an EMIT dataset read into an xarray dataset using the emit_xarray function and then writes an ENVI file and header. 
+
+    Parameters:
+    xr_ds: an EMIT dataset read into xarray using the emit_xarray function.
+    output_dir: output directory
+    overwrite: overwrite existing file if True
+    extension: the file extension for the envi formatted file, .img by default.
+    glt_file: also create a GLT ENVI file for later use to reproject
+
+    Returns:
+    envi_ds: file in the output directory
+    glt_ds: file in the output directory
+    
+    """
+    # Check if xr_ds has been orthorectified, raise exception if it has been but GLT is still requested
+    if 'Orthorectified' in xr_ds.attrs.keys() and xr_ds.attrs['Orthorectified'] == 'True' and glt_file == True:
+            raise Exception('Data is already orthorectified.')
+    
+    # Typemap dictionary for ENVI files
+    envi_typemap = {
+    'uint8': 1,
+    'int16': 2,
+    'int32': 3,
+    'float32': 4,
+    'float64': 5,
+    'complex64': 6,
+    'complex128': 9,
+    'uint16': 12,
+    'uint32': 13,
+    'int64': 14,
+    'uint64': 15
+    }
+    
+    # Get CRS/geotransform for creation of Orthorectified ENVI file or optional GLT file
+    gt = xr_ds.attrs['geotransform']
+    mapinfo = '{Geographic Lat/Lon, 1, 1, ' + str(gt[0]) + ', ' + str(gt[3]) + ', ' + str(gt[1]) + ', ' + str(gt[5]) +', WGS 84, units=Degrees}'
+    
+    # This creates the coordinate system string - ENVI hdr does not seem to support the optional authority and axis fields
+    # hard-coded replacement of wkt crs could probably be improved, though should be the same for all EMIT datasets
+    csstring = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
+
+    # List data variables (typically reflectance/radiance)
+    var_names = list(xr_ds.data_vars)
+
+    # Loop through variable names
+    for var in var_names:
+        # Define output filename
+        output_name = os.path.join(output_dir, xr_ds.attrs['granule_id'] + '_' + var)
+    
+        # Start building metadata
+        metadata = {
+                'lines': xr_ds[var].data.shape[0],
+                'samples': xr_ds[var].data.shape[1],
+                'bands': xr_ds[var].data.shape[2],
+                'interleave': interleave,
+                'header offset' : 0,
+                'file type' : 'ENVI Standard',
+                'data type' : envi_typemap[str(xr_ds[var].data.dtype)],
+                'byte order' : 0
+            }
+    
+        for key in list(xr_ds.attrs.keys()):
+                if key == 'summary':
+                    metadata['description'] = xr_ds.attrs[key]
+                elif key not in ['geotransform','spatial_ref']:
+                    metadata[key] = f'{{ {xr_ds.attrs[key]} }}'
+    
+        # List all variables in dataset (including coordinate variables)
+        meta_vars = list(xr_ds.variables) 
+
+        # Add wavelength information to metadata
+        for m in meta_vars:
+            if m == 'wavelengths' or m == 'radiance_wl':
+                metadata['wavelength'] = np.array(xr_ds[m].data).astype(str).tolist()
+            elif m == 'fwhm' or m == 'radiance_fwhm':
+                metadata['fwhm'] = np.array(xr_ds[m].data).astype(str).tolist()
+            if 'wavelength' in list(metadata.keys()) and 'band names' not in list (metadata.keys()):
+                metadata['band names'] = metadata['wavelength']
+    
+        # Add CRS/mapinfo if xarray dataset has been orthorectified
+        if 'Orthorectified' in xr_ds.attrs.keys() and xr_ds.attrs['Orthorectified'] == 'True':
+            metadata['coordinate system string']= csstring
+            metadata['map info'] = mapinfo
+        # Write Variables as ENVI Output
+        envi_ds = envi.create_image(envi_header(output_name), metadata, ext=extension, force=overwrite)
+        mm = envi_ds.open_memmap(interleave='bip', writable=True)   
+        mm[...]= xr_ds[var].data
+
+    # Create GLT Metadata/File
+    if glt_file == True:
+        # Output Name
+        glt_output_name = os.path.join(output_dir, xr_ds.attrs['granule_id'] + '_' + 'glt')
+            
+        # Write GLT Metadata
+        glt_metadata = metadata
+        
+        # Remove Unwanted Metadata
+        del glt_metadata['wavelength']
+        del glt_metadata['fwhm']
+        
+        # Replace Metadata 
+        glt_metadata['lines'] = xr_ds['glt_x'].data.shape[0]
+        glt_metadata['samples'] = xr_ds['glt_x'].data.shape[1]
+        glt_metadata['bands'] = 2
+        glt_metadata['data type'] = envi_typemap['int32']
+        glt_metadata['band names'] = ['glt_x', 'glt_y']
+        glt_metadata['coordinate system string']= csstring
+        glt_metadata['map info'] = mapinfo
+        
+        # Write GLT Outputs as ENVI File
+        glt_ds = envi.create_image(envi_header(glt_output_name), glt_metadata, ext=extension, force=overwrite)
+        mmglt = glt_ds.open_memmap(interleave='bip', writable=True)
+        mmglt[...] = np.stack((xr_ds['glt_x'].values,xr_ds['glt_y'].values),axis=-1).astype('int32')
+    
+
+
+def envi_header(inputpath):
+    """
+    Convert a envi binary/header path to a header, handling extensions
+    Args:
+        inputpath: path to envi binary file
+    Returns:
+        str: the header file associated with the input reference.
+    """
+    if os.path.splitext(inputpath)[-1] == '.img' or os.path.splitext(inputpath)[-1] == '.dat' or os.path.splitext(inputpath)[-1] == '.raw':
+        # headers could be at either filename.img.hdr or filename.hdr.  Check both, return the one that exists if it
+        # does, if not return the latter (new file creation presumed).
+        hdrfile = os.path.splitext(inputpath)[0] + '.hdr'
+        if os.path.isfile(hdrfile):
+            return hdrfile
+        elif os.path.isfile(inputpath + '.hdr'):
+            return inputpath + '.hdr'
+        return hdrfile
+    elif os.path.splitext(inputpath)[-1] == '.hdr':
+        return inputpath
+    else:
+        return inputpath + '.hdr'
+

--- a/setup/emit_tutorials.yml
+++ b/setup/emit_tutorials.yml
@@ -34,6 +34,7 @@ dependencies:
   - lxml
   - ipyleaflet
   - sidecar
+  - spectral>=0.21
   - jupyterlab-geojson
   - jupyterlab-git
   - jupyter-resource-usage


### PR DESCRIPTION
When we add an example of using this function to a notebook, we will need to either add the spectral package to the cloud workspace or provide instructions to install it. I've added it to the .yml, so if working locally this should not be an issue for users.