### PR TITLE
Fix handling for HTTPFileSystem URIs

### DIFF
--- a/modules/emit_tools.py
+++ b/modules/emit_tools.py
@@ -23,6 +23,7 @@ import pandas as pd
 import xarray as xr
 import rasterio as rio
 import s3fs
+from fsspec.implementations.http import HTTPFile
 
 def emit_xarray(filepath, ortho=True, qmask=None, unpacked_bmask=None): 
     """
@@ -49,6 +50,8 @@ def emit_xarray(filepath, ortho=True, qmask=None, unpacked_bmask=None):
     out_xr = xr.Dataset(data_vars=data_vars, coords = coords, attrs= ds.attrs)
     if type(filepath) == s3fs.core.S3File:
         out_xr.attrs['granule_id'] = filepath.info()['name'].split('/',-1)[-1].split('.',-1)[0]
+    elif type(filepath) == HTTPFile:
+        out_xr.attrs['granule_id'] = filepath.path.split('/',-1)[-1].split('.',-1)[0]
     else:
         out_xr.attrs['granule_id'] = os.path.splitext(os.path.basename(filepath))[0]
     


### PR DESCRIPTION
In order to load EMIT data over HTTP, it's best to use a `token` to authenticate using `fsspec` as documented in [this comment](https://github.com/nsidc/earthaccess/issues/188#issuecomment-1363450269).

This below is working code, but it requires this attached fix.

```
s3_url = "s3://lp-prod-protected/EMITL2ARFL.001/EMIT_L2A_RFL_001_20230123T004529_2302216_003/EMIT_L2A_RFL_001_20230123T004529_2302216_003.nc"
s3_url = s3_url.replace("s3://", "https://data.lpdaac.earthdatacloud.nasa.gov/")

fs = HTTPFileSystem(headers={
    "Authorization": f"bearer {token}"
})
# ds = xr.open_dataset(fs.open(s3_url))
ds = emit_xarray(fs.open(s3_url))
ds
```