### PR TITLE
Add wavelength lookup for bands

### DIFF
--- a/modules/emit_tools.py
+++ b/modules/emit_tools.py
@@ -183,14 +183,18 @@ def ortho_xr(ds, GLT_NODATA_VALUE=0, fill_value = -9999):
     
     # Delete glt_ds - no longer needed
     del glt_ds
-    
+
     # Create Coordinate Dictionary
-    coords = {'latitude':(['latitude'],lat), 'longitude':(['longitude'],lon), **ds.coords}# unpack to add appropriate coordinates 
-    
-    # Remove Unnecessary Coords
-    for key in ['downtrack','crosstrack','lat','lon','glt_x','glt_y','elev']:
+    coords = {
+        'latitude': (['latitude'], lat),
+        'longitude': (['longitude'], lon),
+        'bands': ds.wavelengths.values,
+        **ds.coords
+    }
+
+    for key in ['downtrack', 'crosstrack', 'lat', 'lon', 'glt_x', 'glt_y', 'elev']:
         del coords[key]
-    
+
     # Add Orthocorrected Elevation
     #coords['elev'] = (['latitude','longitude'], np.squeeze(elev_ds))
 


### PR DESCRIPTION
This PR adds an index for the `bands` dimension, which enables selecting a band simpler than
is happening in the examples now.

For example, rather than doing: `np.nanargmin(abs(ds["wavelengths"].values - band))`

You can now do: `ds.sel(bands=450, method="nearest")`

This simplifies a lot of things, including plotting with holoviews. Example captured below in an image.

![image](https://github.com/nasa/EMIT-Data-Resources/assets/3445853/3c4937b3-b747-41df-91ac-72d6f24e4398)
