### PR TITLE
Fix to elevation during orthorectification

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 _________________________________________________________________________
 
+## 2023-10-23
+
+> ### Changed
+>
+> - Updated `emit_tools.py` to fix an issue with application of the GLT to elevation
+
 ## 2023-10-12
 
 > ### Changed

--- a/python/modules/emit_tools.py
+++ b/python/modules/emit_tools.py
@@ -200,7 +200,7 @@ def ortho_xr(ds, GLT_NODATA_VALUE=0, fill_value = -9999):
     for var in var_list:
         raw_ds = ds[var].data
         var_dims = ds[var].dims
-        # Apply GLT to dataset - use a copy here otherwise decrementing glt_array from apply_glt will persist
+        # Apply GLT to dataset 
         out_ds = apply_glt(raw_ds,glt_ds, GLT_NODATA_VALUE=GLT_NODATA_VALUE)
         
         # Mask fill values

--- a/python/modules/emit_tools.py
+++ b/python/modules/emit_tools.py
@@ -162,9 +162,10 @@ def apply_glt(ds_array,glt_array,fill_value=-9999,GLT_NODATA_VALUE=0):
     out_ds = np.full((glt_array.shape[0], glt_array.shape[1], ds_array.shape[-1]), fill_value, dtype=np.float32)
     valid_glt = np.all(glt_array != GLT_NODATA_VALUE, axis=-1)
     
-    # Adjust for One based Index
-    glt_array[valid_glt] -= 1 
-    out_ds[valid_glt, :] = ds_array[glt_array[valid_glt, 1], glt_array[valid_glt, 0], :]
+    # Adjust for One based Index - make a copy to prevent decrementing multiple times inside ortho_xr when applying the glt to elev
+    glt_array_copy = glt_array.copy()
+    glt_array_copy[valid_glt] -= 1
+    out_ds[valid_glt, :] = ds_array[glt_array_copy[valid_glt, 1], glt_array_copy[valid_glt, 0], :]
     return out_ds
 
 def ortho_xr(ds, GLT_NODATA_VALUE=0, fill_value = -9999):
@@ -199,7 +200,7 @@ def ortho_xr(ds, GLT_NODATA_VALUE=0, fill_value = -9999):
     for var in var_list:
         raw_ds = ds[var].data
         var_dims = ds[var].dims
-        # Apply GLT to dataset
+        # Apply GLT to dataset - use a copy here otherwise decrementing glt_array from apply_glt will persist
         out_ds = apply_glt(raw_ds,glt_ds, GLT_NODATA_VALUE=GLT_NODATA_VALUE)
         
         # Mask fill values


### PR DESCRIPTION
During the orthorectification process, the glt_array is used twice. This fix decrements a copy to adjust to a one-based index so the glt_array doesn't persist and get decremented twice. This was happening causing an incorrect elevation value to be returned during orthorectification.