### PR TITLE
Update fetch_ch4_metadata function

### DIFF
--- a/python/tutorials/Visualizing_Methane_Plume_Timeseries.ipynb
+++ b/python/tutorials/Visualizing_Methane_Plume_Timeseries.ipynb
@@ -415,7 +415,8 @@
     "# Speed could be improved here by using asyncio/aiohttp\n",
     "def fetch_ch4_metadata(row):\n",
     "    response = requests.get(get_asset_url(row, 'CH4PLMMETA'))\n",
-    "    return response.json()['features'][0]['properties']"
+    "    json = response.json()\n",
+    "    return json['features'][0]['properties']"
    ]
   },
   {


### PR DESCRIPTION
Updated fetch_ch4_metadata function. In some cases indexing the json object without assigning it a variable would cause an error.

Related: Issue-55